### PR TITLE
Fix exception with nested fields

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -35,7 +35,7 @@ const checkRequiredParameters = (customArgs: CustomValidatorArgs, values) => {
 };
 
 const getValueByCustomArgs = (values, { field }: CustomValidatorArgs) =>
-  field.split('.').reduce((value, key) => value[key], values);
+  field.split('.').reduce((value, key) => value ? value[key] : null, values);
 
 const hasToBeRequired = (values, customArgs: CustomValidatorArgs): boolean => {
   const customArgFieldValue = getValueByCustomArgs(values, customArgs);


### PR DESCRIPTION
Fix #2 

When form state is null, `getValueByCustomArgs` produce an exception in case of nested fields.
`value` is undefined, and accessing `value[key]` goes wrong.